### PR TITLE
Remove duplicate ActiveRecord dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 *.sqlite3
 *.db
-Gemfile.lock
 gemfiles/*.lock
 pkg
 rdoc

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,19 +2,8 @@ language: ruby
 
 matrix:
   include:
-    - { rvm: 1.9.3, gemfile: gemfiles/activerecord_3_2.gemfile, env: DB=mysql    }
-
     - { rvm: 1.9.3, gemfile: gemfiles/activerecord_3_2.gemfile, env: DB=postgres }
-
-    - { rvm: 1.8.7, gemfile: gemfiles/activerecord_3_2.gemfile, env: DB=mysql    }
-    - { rvm: 1.9.2, gemfile: gemfiles/activerecord_3_2.gemfile, env: DB=mysql    }
-    - { rvm: 2.0.0, gemfile: gemfiles/activerecord_3_2.gemfile, env: DB=mysql    }
-
-    - { rvm: 1.8.7, gemfile: gemfiles/activerecord_2_2.gemfile, env: DB=mysql    }
-    - { rvm: 1.9.3, gemfile: gemfiles/activerecord_2_3.gemfile, env: DB=mysql    }
-    - { rvm: 1.9.3, gemfile: gemfiles/activerecord_3_0.gemfile, env: DB=mysql    }
-    - { rvm: 1.9.3, gemfile: gemfiles/activerecord_3_1.gemfile, env: DB=mysql    }
-    - { rvm: 1.9.3, gemfile: gemfiles/activerecord_3_2.gemfile, env: DB=mysql    }
+    - { rvm: 2.2.2, gemfile: gemfiles/activerecord_3_2.gemfile, env: DB=postgres }
 
 before_script:
   - sh -c "if [ '$DB' = 'mysql' ]; then mysql -e 'create database if not exists oauth2_test;'; fi"

--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,4 @@ group :development do
   gem "activerecord", "~> 3.2.0" # The SQLite adapter in 3.1 is broken
 end
 
-group :development, :test do
-  gem "rspec", "~> 2.14.1"
-end
-
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,7 @@
 source 'https://rubygems.org'
-gemspec
 
+group :development do
+  gem "activerecord", "~> 3.2.0" # The SQLite adapter in 3.1 is broken
+end
+
+gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,8 @@ group :development do
   gem "activerecord", "~> 3.2.0" # The SQLite adapter in 3.1 is broken
 end
 
+group :development, :test do
+  gem "rspec", "~> 2.14.1"
+end
+
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,9 +21,10 @@ GEM
     activesupport (3.2.22)
       i18n (~> 0.6, >= 0.6.4)
       multi_json (~> 1.0)
-    appraisal (0.4.1)
+    appraisal (2.0.2)
       bundler
       rake
+      thor (>= 0.14.0)
     arel (3.0.3)
     bcrypt (3.1.10)
     bcrypt-ruby (3.1.5)
@@ -65,6 +66,7 @@ GEM
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0)
       rack (~> 1.0)
+    thor (0.19.1)
     tilt (2.0.1)
     tzinfo (0.3.44)
 
@@ -73,7 +75,7 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord (~> 3.2.0)
-  appraisal (~> 0.4.0)
+  appraisal
   factory_girl (~> 2.0)
   pry
   rspec (~> 2.14.1)
@@ -81,3 +83,6 @@ DEPENDENCIES
   songkick-oauth2-provider!
   sqlite3
   thin
+
+BUNDLED WITH
+   1.10.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,83 @@
+PATH
+  remote: .
+  specs:
+    songkick-oauth2-provider (0.10.2)
+      activerecord
+      bcrypt-ruby
+      json
+      rack
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activemodel (3.2.22)
+      activesupport (= 3.2.22)
+      builder (~> 3.0.0)
+    activerecord (3.2.22)
+      activemodel (= 3.2.22)
+      activesupport (= 3.2.22)
+      arel (~> 3.0.2)
+      tzinfo (~> 0.3.29)
+    activesupport (3.2.22)
+      i18n (~> 0.6, >= 0.6.4)
+      multi_json (~> 1.0)
+    appraisal (0.4.1)
+      bundler
+      rake
+    arel (3.0.3)
+    bcrypt (3.1.10)
+    bcrypt-ruby (3.1.5)
+      bcrypt (>= 3.1.3)
+    builder (3.0.4)
+    coderay (1.1.0)
+    daemons (1.2.3)
+    diff-lcs (1.2.5)
+    eventmachine (1.0.7)
+    factory_girl (2.6.4)
+      activesupport (>= 2.3.9)
+    i18n (0.7.0)
+    json (1.8.3)
+    method_source (0.8.2)
+    multi_json (1.11.2)
+    pry (0.10.1)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    rack (1.6.4)
+    rack-protection (1.5.3)
+      rack
+    rake (10.4.2)
+    rspec (2.14.1)
+      rspec-core (~> 2.14.0)
+      rspec-expectations (~> 2.14.0)
+      rspec-mocks (~> 2.14.0)
+    rspec-core (2.14.8)
+    rspec-expectations (2.14.5)
+      diff-lcs (>= 1.1.3, < 2.0)
+    rspec-mocks (2.14.6)
+    sinatra (1.4.6)
+      rack (~> 1.4)
+      rack-protection (~> 1.4)
+      tilt (>= 1.3, < 3)
+    slop (3.6.0)
+    sqlite3 (1.3.10)
+    thin (1.6.3)
+      daemons (~> 1.0, >= 1.0.9)
+      eventmachine (~> 1.0)
+      rack (~> 1.0)
+    tilt (2.0.1)
+    tzinfo (0.3.44)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  activerecord (~> 3.2.0)
+  appraisal (~> 0.4.0)
+  factory_girl (~> 2.0)
+  pry
+  rspec (~> 2.14.1)
+  sinatra (>= 1.3.0)
+  songkick-oauth2-provider!
+  sqlite3
+  thin

--- a/songkick-oauth2-provider.gemspec
+++ b/songkick-oauth2-provider.gemspec
@@ -17,10 +17,11 @@ spec = Gem::Specification.new do |s|
   s.add_dependency("json")
   s.add_dependency("rack")
 
-  s.add_development_dependency("appraisal", "~> 0.4.0")
+  s.add_development_dependency("appraisal")
   s.add_development_dependency("mysql", "~> 2.8.0") if ENV["DB"] == "mysql" # version locked by ActiveRecord
   s.add_development_dependency("pg") if ENV["DB"] == "postgres"
   s.add_development_dependency("sqlite3")
+  s.add_development_dependency("rspec", "~> 2.14.1")
   s.add_development_dependency("pry")
   s.add_development_dependency("sinatra", ">= 1.3.0")
   s.add_development_dependency("thin")

--- a/songkick-oauth2-provider.gemspec
+++ b/songkick-oauth2-provider.gemspec
@@ -20,7 +20,6 @@ spec = Gem::Specification.new do |s|
   s.add_development_dependency("appraisal", "~> 0.4.0")
   s.add_development_dependency("mysql", "~> 2.8.0") if ENV["DB"] == "mysql" # version locked by ActiveRecord
   s.add_development_dependency("pg") if ENV["DB"] == "postgres"
-  s.add_development_dependency("rspec")
   s.add_development_dependency("sqlite3")
   s.add_development_dependency("pry")
   s.add_development_dependency("sinatra", ">= 1.3.0")

--- a/songkick-oauth2-provider.gemspec
+++ b/songkick-oauth2-provider.gemspec
@@ -18,7 +18,6 @@ spec = Gem::Specification.new do |s|
   s.add_dependency("rack")
 
   s.add_development_dependency("appraisal", "~> 0.4.0")
-  s.add_development_dependency("activerecord", "~> 3.2.0") # The SQLite adapter in 3.1 is broken
   s.add_development_dependency("mysql", "~> 2.8.0") if ENV["DB"] == "mysql" # version locked by ActiveRecord
   s.add_development_dependency("pg") if ENV["DB"] == "postgres"
   s.add_development_dependency("rspec")


### PR DESCRIPTION
:information_desk_person: The gemspec defines ActiveRecord as a dependency twice, the second of which attempts to ensure that a compatible version is available for development. Migrating this version lock to the Gemfile results in the same behaviour, without the inconvenience of Bundler >= v1.10.1 refusing to install the gem due to an invalid gemspec.

An example of this error message follows:
```
/opt/rubies/2.2.2/gems/bundler-1.10.3/lib/bundler.rb:374:in `rescue in load_gemspec_uncached':
The gemspec at /www/sites/demo/vendor/bundle/ruby/2.2.2/bundler/gems/oauth2-provider-b60ea985a0e9/songkick-oauth2-provider.gemspec
is not valid. The validation error was 'duplicate dependency on activerecord (~> 3.2.0, development), (>= 0) use: (Bundler::InvalidOption)
    add_runtime_dependency 'activerecord', '~> 3.2.0', '>= 0'
```